### PR TITLE
Fix duplication glitch with the Transfer Assembler

### DIFF
--- a/Tiles/TransferAssemblerTileEntity.cs
+++ b/Tiles/TransferAssemblerTileEntity.cs
@@ -51,7 +51,8 @@ namespace MechTransfer.Tiles
         public override TagCompound Save()
         {
             TagCompound tags = base.Save();
-            tags.Add("stck", ItemIO.Save(stock));
+            if (stock.stack > 0)
+                tags.Add("stck", ItemIO.Save(stock));
             return tags;
         }
 


### PR DESCRIPTION
If you save and reload a world after an assembler has crafted something, you'll get one extra item each time you reload. This is because `ItemIO.Save()` only includes the stack size if it's greater than one (see [ItemIO.cs](https://github.com/tModLoader/tModLoader/blob/v0.11.7.5/patches/tModLoader/Terraria.ModLoader.IO/ItemIO.cs#L44)), so if `stock` is empty, the stack size will default to one when loaded. To avoid this, we can skip saving the `stock` data if it's empty.